### PR TITLE
feat: false-positives per repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'    
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,12 +15,22 @@
 #    limitations under the License.
 #   ######################################################################## export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
+WORKSPACE_DIR=/github/workspace
+FALSE_POSITIVE_FILE="${WORKSPACE_DIR}/.false-positives.yaml"
+IGNORE_FILE="${WORKSPACE_DIR}/.ge_ignore"
+
 if [ -d ".go-earlybird" ]; then
  cp -f .go-earlybird/* /.go-earlybird/
 fi
 
+if [ -f "${FALSE_POSITIVE_FILE}" ]; then
+ cp "${FALSE_POSITIVE_FILE}" /.go-earlybird/falsepositives
+fi
+
+
 echo ::group::scanner_output
-go-earlybird  -show-solutions -suppress -config=/.go-earlybird/  -ignorefile=/.ge_ignore -path=/github/workspace/${INPUT_WORKDIR} ${INPUT_ARGS} || true
+go-earlybird  -show-solutions -suppress -config=/.go-earlybird/ -ignorefile="${IGNORE_FILE}" -ignorefile=/.ge_ignore \
+    -path=/github/workspace/${INPUT_WORKDIR} ${INPUT_ARGS} || true
 echo "::endgroup::"
 echo ::group::reviewdog_output
 
@@ -36,7 +46,7 @@ else
     export REPORTER=$INPUT_REPORTER
 fi
 
-go-earlybird  -show-solutions -suppress -config=/.go-earlybird/  -ignorefile=/.ge_ignore \
+go-earlybird  -show-solutions -suppress -config=/.go-earlybird/ -ignorefile="${IGNORE_FILE}" -ignorefile=/.ge_ignore \
     -path=/github/workspace/${INPUT_WORKDIR} -format=json ${INPUT_ARGS} \
     | python3 /annotate.py \
     | reviewdog -f=rdjson  \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 
 echo ::group::scanner_output
 go-earlybird  -show-solutions -suppress -config=/.go-earlybird/ -ignorefile="${IGNORE_FILE}" -ignorefile=/.ge_ignore \
-    -path=/github/workspace/${INPUT_WORKDIR} ${INPUT_ARGS} || true
+    -path=${WORKSPACE_DIR}/${INPUT_WORKDIR} ${INPUT_ARGS} || true
 echo "::endgroup::"
 echo ::group::reviewdog_output
 
@@ -47,7 +47,7 @@ else
 fi
 
 go-earlybird  -show-solutions -suppress -config=/.go-earlybird/ -ignorefile="${IGNORE_FILE}" -ignorefile=/.ge_ignore \
-    -path=/github/workspace/${INPUT_WORKDIR} -format=json ${INPUT_ARGS} \
+    -path=${WORKSPACE_DIR}/${INPUT_WORKDIR} -format=json ${INPUT_ARGS} \
     | python3 /annotate.py \
     | reviewdog -f=rdjson  \
       -name="addonfactory-sample-scanner" \


### PR DESCRIPTION
PR to address INFRA-35376

- giving chance to create per repository `.ge_ignore` and/or `.false-positives.yaml` files with exceptions for sample-scanner

It was tested with: https://github.com/splunk/splunk-add-on-for-microsoft-windows/tree/test/false-positive-check